### PR TITLE
fix

### DIFF
--- a/frontend/src/app/component/Navbar.tsx
+++ b/frontend/src/app/component/Navbar.tsx
@@ -33,7 +33,7 @@ const Navbar: React.FC = () => {
     // Check if already connected
     if (window.ethereum) {
       window.ethereum.request({ method: 'eth_accounts' })
-          .then(accounts => {
+          .then((accounts: string) => {
             if (accounts.length > 0) {
               connectWallet();
             }

--- a/frontend/src/app/homepage/page.tsx
+++ b/frontend/src/app/homepage/page.tsx
@@ -168,7 +168,7 @@ export default function HomePage() {
         // Vérifier si le wallet est déjà connecté
         if (window.ethereum) {
             window.ethereum.request({ method: 'eth_accounts' })
-                .then(accounts => {
+                .then((accounts: any) => {
                     if (accounts.length > 0) {
                         setIsConnected(true);
                         setUserAddress(accounts[0]);


### PR DESCRIPTION
This pull request includes type annotations for the `accounts` parameter in two different files to improve type safety.

Type annotations added:

* [`frontend/src/app/component/Navbar.tsx`](diffhunk://#diff-b27f92d10e1b6bbef30a38eaaa4f7f2d6e11d69b4e1b546ac6aeaa6463ecf213L36-R36): Changed the type of `accounts` to `string` in the `then` method of the Ethereum request.
* [`frontend/src/app/homepage/page.tsx`](diffhunk://#diff-5e9a21f8bdc1b0ce49373fa60b1c8c0adeba3f73a4632aac1515f1981ba289a9L171-R171): Changed the type of `accounts` to `any` in the `then` method of the Ethereum request.